### PR TITLE
Add error handling adwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@ module.exports = function(environment) {
             id: 'UA-XXXXXXXX-Y',
             remarketing: true,
             ecommerce: true,
-            enhancedEcommerce: false
+            enhancedEcommerce: false,
+            set: {
+              anonymizeIp: true
+            }
           }
         },
         {

--- a/addon/integrations/google-adwords.js
+++ b/addon/integrations/google-adwords.js
@@ -46,7 +46,12 @@ export default Base.extend({
     }
 
     if (canUseDOM) {
-      window['google_trackConversion'](googleAdwordsEvent);
+      try {
+        window['google_trackConversion'](googleAdwordsEvent);
+      }
+      catch (err) {
+        Ember.debug(err);
+      }
     }
   },
 

--- a/addon/integrations/google-analytics.js
+++ b/addon/integrations/google-analytics.js
@@ -111,8 +111,8 @@ export default Base.extend({
    */
   insertTag: on('init', function() {
     const config = copy(get(this, 'config'));
-    const { id, remarketing, ecommerce, enhancedEcommerce } = config;
-    const properties = without(config, 'id', 'remarketing', 'ecommerce', 'enhancedEcommerce');
+    const { id, remarketing, ecommerce, enhancedEcommerce, set } = config;
+    const properties = without(config, 'id', 'remarketing', 'ecommerce', 'enhancedEcommerce', 'set');
 
     assert('You must pass a valid `id` to the GoogleAnaltics adapter', id);
 
@@ -140,6 +140,11 @@ export default Base.extend({
 
       if (enhancedEcommerce) {
         window.ga('require', 'ecommerce');
+      }
+      if (set) {
+        for ( const attr of Object.keys(set) ) {
+          window.ga('set', attr, set[attr]);
+        }
       }
     }
   }),


### PR DESCRIPTION
The adwords adapter currently throws an error if used with firefox & tracking protection.
I enclosed the call to adwords with try catch to make sure no javascript error is thrown.

