### PR TITLE
Adding options for incorporating analytics scripts into the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,29 @@ From within your Ember CLI project directory run:
 ember install ember-cli-analytics
 ```
 
+### Options for higher-security implementations
+
+Some higher-security sites want to prohibit all script-based access to
+third-party sites. If this is the case for your site, you might prefer to
+download the analytics scripts to your `vendor` location first and then
+incorporate them into your ember application via the build process. For example,
+for google analytics, you would do the following:
+
+```sh
+  curl https://www.google-analytics.com/analytics.js > vendor/google-analytics.js
+```
+
+Then, to load the script as part of the build process, add a command to your
+`ember-cli-build.js` file. For the Google Analytics example, you would do the
+following:
+
+```js
+  app.import('vendor/google-analytics.js')
+```
+
+If you have loaded the scripts into your application via the build process,
+`ember-cli-analytics` will _not_ attempt to download them when necessary.
+
 ## Usage
 
 This addon implements a service to interface with several analytics integration

--- a/addon/integrations/bing.js
+++ b/addon/integrations/bing.js
@@ -56,7 +56,9 @@ export default Base.extend({
 
     assert('You must pass a valid `id` to the Bing adapter', id);
 
-    if (canUseDOM) {
+    if (!canUseDOM) return
+
+    if (!window.uetq) {
       /* eslint-disable */
       (function(w,d,t,r,u){var f,n,i;w[u]=w[u]||[],f=function(){
         var o={ti:id};o.q=w[u],w[u]=new UET(o),w[u].push('pageLoad')},

--- a/addon/integrations/facebook.js
+++ b/addon/integrations/facebook.js
@@ -75,7 +75,9 @@ export default Base.extend({
 
     assert('You must pass a valid `id` to the Bing adapter', id);
 
-    if (canUseDOM) {
+    if (!canUseDOM) return
+
+    if (!window.fbq) {
       /* eslint-disable */
       (function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){
         n.callMethod?n.callMethod.apply(n,arguments):n.queue.push(arguments)};
@@ -84,9 +86,9 @@ export default Base.extend({
         s.parentNode.insertBefore(t,s)
       })(window,document,'script','//connect.facebook.net/en_US/fbevents.js');
       /* eslint-enable */
-
-      window.fbq('init', id);
     }
+
+    window.fbq('init', id);
   }),
 
   /*

--- a/addon/integrations/google-adwords.js
+++ b/addon/integrations/google-adwords.js
@@ -58,7 +58,7 @@ export default Base.extend({
    * @on init
    */
   insertTag: on('init', function() {
-    if (canUseDOM) {
+    if (canUseDOM && !window['google_trackConversion']) {
       /* eslint-disable */
       (function(i,s,o,g,r,a,m){
         i[r]=i[r]||function(){(i['r'].q=i['r'].q||[]).push(arguments)}

--- a/addon/integrations/google-analytics.js
+++ b/addon/integrations/google-analytics.js
@@ -34,7 +34,7 @@ export default Base.extend({
 
   /*
    * Send an arbitrary event to the
-   * anlytics engine.
+   * analytics engine.
    *
    * @method trackEvent
    *
@@ -108,36 +108,38 @@ export default Base.extend({
 
     assert('You must pass a valid `id` to the GoogleAnaltics adapter', id);
 
-    if (canUseDOM) {
+    if (!canUseDOM) return
+
+    if (!window.ga) {
       /* eslint-disable */
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
       /* eslint-enable */
+    }
 
-      if (isPresent(Object.keys(properties))) {
-        window.ga('create', id, properties);
-      } else {
-        window.ga('create', id, 'auto');
-      }
+    if (isPresent(Object.keys(properties))) {
+      window.ga('create', id, properties);
+    } else {
+      window.ga('create', id, 'auto');
+    }
 
-      if (remarketing) {
-        window.ga('require', 'displayfeatures');
-      }
+    if (remarketing) {
+      window.ga('require', 'displayfeatures');
+    }
 
-      if (ecommerce) {
-        window.ga('require', 'ecommerce');
-      }
+    if (ecommerce) {
+      window.ga('require', 'ecommerce');
+    }
 
-      if (enhancedEcommerce) {
-        window.ga('require', 'ecommerce');
-      }
+    if (enhancedEcommerce) {
+      window.ga('require', 'ecommerce');
+    }
 
-      if (set) {
-        for (const attr of Object.keys(set)) {
-          window.ga('set', attr, set[attr]);
-        }
+    if (set) {
+      for (const attr of Object.keys(set)) {
+        window.ga('set', attr, set[attr]);
       }
     }
   }),

--- a/addon/integrations/mixpanel.js
+++ b/addon/integrations/mixpanel.js
@@ -146,7 +146,7 @@ export default Base.extend({
 
     assert('You must pass a valid `token` to the Mixpanel adapter', token);
 
-    if (canUseDOM) {
+    if (canUseDOM && !window.mixpanel) {
       /* eslint-disable */
       const regex = /^\/\//;
       (function(e,b){if(!b.__SV){var a,f,i,g;window.mixpanel=b;b._i=[];b.init=function(a,e,d){function f(b,h){var a=h.split(".");2==a.length&&(b=b[a[0]],h=a[1]);b[h]=function(){b.push([h].concat(Array.prototype.slice.call(arguments,0)))}}var c=b;"undefined"!==typeof d?c=b[d]=[]:d="mixpanel";c.people=c.people||[];c.toString=function(b){var a="mixpanel";"mixpanel"!==d&&(a+="."+d);b||(a+=" (stub)");return a};c.people.toString=function(){return c.toString(1)+".people (stub)"};i="disable time_event track track_pageview track_links track_forms register register_once alias unregister identify name_tag set_config people.set people.set_once people.increment people.append people.union people.track_charge people.clear_charges people.delete_user".split(" ");

--- a/addon/integrations/optimizely.js
+++ b/addon/integrations/optimizely.js
@@ -71,7 +71,7 @@ export default Base.extend({
 
     assert('You must pass a valid `id` to the Optimizely adapter', id);
 
-    if (canUseDOM) {
+    if (canUseDOM && !window.optimizely) {
       /* eslint-disable */
       (function(i,s,o,g,r,a,m){
         i['OptimizrlyObject']=r;i[r]=i[r]||[];a=s.createElement(o),


### PR DESCRIPTION
Currently ember-cli-analytics will _always_ attempt to download analytics scripts from their origins and will fail if those sites are blocked with a content-security-policy. However, it is possible to incorporate those scripts using the build process and not to need a hole punched in the CSP for this activity. Some higher-security sites might prefer this option. 

This PR allows for this avenue to be used.