### PR TITLE
Adding option to limit route information

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,23 @@ the name of each adapter, in pascal case, this addon also requires a
 configuration object typically defining the `id` or `token` required to
 authenticate with the external service.
 
+#### Options
+
+In addition under the `analytics` configuration heading, it is also possible to set an option `limitRouteInformation`. Some higher-security sites may have sensitive information embedded in their routes such as email addresses or invitation codes which should not be leaked to any third-parties. If you set `limitRouteInformation` to `true`, then `ember-cli-analytics` will only send the current route name to an analytics service rather than the entire URL.
+
+For example:
+
+```javascript
+// config/environment.js
+module.exports = function(environment) {
+  let ENV = {
+    analytics: {
+      options: {
+        limitRouteInformation: true,
+      },
+    }
+```
+
 ### Injection
 
 This addon makes no assumptions about what ember objects you want to make the

--- a/addon/mixins/trackable.js
+++ b/addon/mixins/trackable.js
@@ -1,5 +1,6 @@
 import Mixin from '@ember/object/mixin';
 
+import { getOwner } from '@ember/application'
 import { assert } from '@ember/debug';
 import { get } from '@ember/object';
 import { on } from '@ember/object/evented';
@@ -25,6 +26,13 @@ export default Mixin.create({
     const analytics = get(this, 'analytics');
 
     assert('Could not find the analytics service.', analytics);
-    analytics.trackPage({ page: get(this, 'url'), title: get(this, 'url') });
+    let limitRouteInformation = false
+    const owner = getOwner(this)
+    if (owner) {
+      const config = owner.resolveRegistration('config:environment')
+      limitRouteInformation = get(config, 'analytics.options.limitRouteInformation')
+    }
+    const routeData = limitRouteInformation ? get(this, 'currentRouteName') : get(this, 'url')
+    analytics.trackPage({ page: routeData, title: routeData });
   })
 });


### PR DESCRIPTION
Our application at Fastly has sensitive information in some of the routes and we have a mandate that we cannot send that information via cleartext to analytics sites which uses non-secured transfer mechanisms like `http) (e.g. google-analytics).

Therefore we need the option to be able to just send Ember's `currentRoute` rather than the full URL which contains some of that sensitive data.